### PR TITLE
Spelling and grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # nwjs-node-packager
 
-A tool to build distribuable packages of a NWJS application.
+A tool to build distributable packages of an NW.js application.
 
 Running on Linux, it targets Linux, Windows and OSX platforms.
 
-It can optionnaly replace the js file with the V8 snapshot to avoid direct reading of source code.
+It can optionally replace the js file with a V8 snapshot to avoid directly reading the source code.
 
 Usage
 ====
@@ -12,25 +12,25 @@ Usage
 $ npm start -- --params ./my-builder-params.js
 ```
 
-if no `--params` is given, the default `params.exemple.js` will be used
+If no file for `--params` is given, the default configuration from `params.example.js` will be used.
 
 Parameters
 ====
 ```js
 const COMMON = {
-    // The directory containing your NWJS script
-    // has to be built if using webpack for example
+    // The directory containing your NW.js script
+    // has to be built if using Webpack for example
     source_dir: '../../../my-nwjs-script/dist',
-    // the directory where NWJS binaries will be donwloaded and uncompressed
-    // this directoru can be kept to avoid new downloads
+    // the directory where NW.js binaries will be donwloaded and decompressed
+    // this directory can be kept to avoid new downloads
     working_dir: './wrk_nwjs',
     // the directory where final packages will be available
     output_dir: './dist',
-    // the nwjs version your script uses
+    // the NW.js version your script uses
     nwjs_version: '0.45.4',
-    // the base url for NWJS redistribuables
+    // the base url for NW.js redistributables
     nwjs_url: 'http://dl.nwjs.io',
-    // clean working_dir to force NWJS binaries download
+    // clean working_dir to force NW.js binaries download
     force_nwjs_download: false,
     // replaces the app script with a binary V8 snapshot
     protect_script: true,
@@ -46,11 +46,11 @@ const COMMON = {
 
 const PLATFORMS = [
     // array for cross-packaging
-    // windows
+    // Windows
     {
         os: 'win',
-        arch: 'x64', // can bie ia32
-        // creates a nsis installer
+        arch: 'x64', // can be ia32
+        // creates an NSIS installer
         installer: {
             app_name: 'Application_Name', // your application name
             app_version: '0.0.0', // application version
@@ -60,7 +60,7 @@ const PLATFORMS = [
             user_install: true // local installation - no need of admin rights for installer
         }
     },
-    // linux
+    // Linux
     {
         os: 'linux',
         arch: 'x64'
@@ -68,9 +68,9 @@ const PLATFORMS = [
 ];
 ```
 
-If your application uses webpack, it has to be built separately.
+If your application uses Webpack, it has to be built separately.
 
-The application will download needed NWJS engines
+The application will download needed NW.js engines
 
 Credits
 ======


### PR DESCRIPTION
I found a few things that were misspelled and some grammar that could be improved, so I wanted to take a second to help out. Also, `params.exemple.js` was misspelled and `params.example.js` is what exists in the repository, so I fixed that as well.